### PR TITLE
feat: bundle wasm_exec.js in release tarballs for ssr-go

### DIFF
--- a/.github/workflows/flappy-bird.yml
+++ b/.github/workflows/flappy-bird.yml
@@ -26,3 +26,5 @@ jobs:
                   goversion: "https://go.dev/dl/go1.24.0.linux-amd64.tar.gz"
                   project_path: "./flappy-bird"
                   binary_name: "flappy-bird.wasm"
+                  pre_command: "cp \"$(go env GOROOT)/lib/wasm/wasm_exec.js\" ."
+                  extra_files: "wasm_exec.js"

--- a/.github/workflows/pong.yml
+++ b/.github/workflows/pong.yml
@@ -26,3 +26,5 @@ jobs:
                   goversion: "https://go.dev/dl/go1.23.0.linux-amd64.tar.gz"
                   project_path: "./pong"
                   binary_name: "pong.wasm"
+                  pre_command: "cp \"$(go env GOROOT)/misc/wasm/wasm_exec.js\" ."
+                  extra_files: "wasm_exec.js"

--- a/.github/workflows/snake.yml
+++ b/.github/workflows/snake.yml
@@ -26,3 +26,5 @@ jobs:
                   goversion: "https://go.dev/dl/go1.22.1.linux-amd64.tar.gz"
                   project_path: "./snake"
                   binary_name: "snake.wasm"
+                  pre_command: "cp \"$(go env GOROOT)/misc/wasm/wasm_exec.js\" ."
+                  extra_files: "wasm_exec.js"

--- a/.github/workflows/tictacgoe.yml
+++ b/.github/workflows/tictacgoe.yml
@@ -25,3 +25,5 @@ jobs:
                   goversion: "https://go.dev/dl/go1.22.1.linux-amd64.tar.gz"
                   project_path: "./tictacgoe/cmd/tictacgoe"
                   binary_name: "tictacgoe.wasm"
+                  pre_command: "cp \"$(go env GOROOT)/misc/wasm/wasm_exec.js\" ."
+                  extra_files: "wasm_exec.js"


### PR DESCRIPTION
Add pre_command and extra_files to go-release-action so each game's release tarball includes wasm_exec.js alongside the .wasm binary. This is required by ssr-go's GameProxy to serve per-game JS glue.

- Go 1.24 (flappy-bird): uses lib/wasm/wasm_exec.js
- Go 1.22/1.23 (snake, pong, tictacgoe): uses misc/wasm/wasm_exec.js