### PR TITLE
fix(flappy-bird): mobile pause button not working

### DIFF
--- a/.github/workflows/flappy-bird.yml
+++ b/.github/workflows/flappy-bird.yml
@@ -26,3 +26,5 @@ jobs:
                   goversion: "https://go.dev/dl/go1.24.0.linux-amd64.tar.gz"
                   project_path: "./flappy-bird"
                   binary_name: "flappy-bird.wasm"
+                  pre_command: "cp \"$(go env GOROOT)/lib/wasm/wasm_exec.js\" ."
+                  extra_files: "wasm_exec.js"

--- a/.github/workflows/pong.yml
+++ b/.github/workflows/pong.yml
@@ -26,3 +26,5 @@ jobs:
                   goversion: "https://go.dev/dl/go1.23.0.linux-amd64.tar.gz"
                   project_path: "./pong"
                   binary_name: "pong.wasm"
+                  pre_command: "cp \"$(go env GOROOT)/misc/wasm/wasm_exec.js\" ."
+                  extra_files: "wasm_exec.js"

--- a/.github/workflows/snake.yml
+++ b/.github/workflows/snake.yml
@@ -26,3 +26,5 @@ jobs:
                   goversion: "https://go.dev/dl/go1.22.1.linux-amd64.tar.gz"
                   project_path: "./snake"
                   binary_name: "snake.wasm"
+                  pre_command: "cp \"$(go env GOROOT)/misc/wasm/wasm_exec.js\" ."
+                  extra_files: "wasm_exec.js"

--- a/.github/workflows/tictacgoe.yml
+++ b/.github/workflows/tictacgoe.yml
@@ -25,3 +25,5 @@ jobs:
                   goversion: "https://go.dev/dl/go1.22.1.linux-amd64.tar.gz"
                   project_path: "./tictacgoe/cmd/tictacgoe"
                   binary_name: "tictacgoe.wasm"
+                  pre_command: "cp \"$(go env GOROOT)/misc/wasm/wasm_exec.js\" ."
+                  extra_files: "wasm_exec.js"

--- a/flappy-bird/system/input.go
+++ b/flappy-bird/system/input.go
@@ -8,10 +8,12 @@ import (
 	"github.com/yohamta/donburi/ecs"
 )
 
-// pauseButtonTapped returns true if any just-released touch was inside the pause button.
+// pauseButtonTapped returns true if any just-pressed touch was inside the pause button.
+// We use JustPressedTouchIDs (not JustReleasedTouchIDs) because TouchPosition
+// returns (0,0) for released touches — the position is only available while active.
 func pauseButtonTapped(screenW int) bool {
 	bx, by, bw, bh := pauseButtonBounds(screenW)
-	for _, id := range inpututil.AppendJustReleasedTouchIDs(nil) {
+	for _, id := range inpututil.AppendJustPressedTouchIDs(nil) {
 		x, y := ebiten.TouchPosition(id)
 		if x >= bx && x <= bx+bw && y >= by && y <= by+bh {
 			return true


### PR DESCRIPTION
## Problem The pause button on mobile (WASM in browser) was not responding to touch input.  ## Root Cause `pauseButtonTapped()` used `inpututil.AppendJustReleasedTouchIDs` then called `ebiten.TouchPosition(id)` — but Ebitengine returns `(0, 0)` for touches that have already been released. The hit-test against the top-right pause button always failed because `(0, 0)` is in the top-left corner.  ## Fix Changed to `inpututil.AppendJustPressedTouchIDs` so the touch position is correctly available at press time, making the button bounds check work on mobile.