### PR TITLE
fix(ldtk-snake): bundle wasm_exec.js in release archive

### DIFF
--- a/.github/workflows/ldtk-snake.yaml
+++ b/.github/workflows/ldtk-snake.yaml
@@ -26,3 +26,5 @@ jobs:
                   goversion: "https://go.dev/dl/go1.22.1.linux-amd64.tar.gz"
                   project_path: "./ldtk-snake"
                   binary_name: "ldtksnake.wasm"
+                  pre_command: "cp \"$(go env GOROOT)/misc/wasm/wasm_exec.js\" ."
+                  extra_files: "wasm_exec.js"


### PR DESCRIPTION
## Problem
The game fails to load in browser with:
```
GET https://stockhause.info/assets/js/wasm_exec.js 404 (Not Found)
WASM load error: SyntaxError: Unexpected identifier 'page'
```

## Root Cause
The `ldtk-snake.yaml` release workflow was not bundling `wasm_exec.js` into the release tarball. The game proxy looks for `wasm_exec.js` inside the downloaded archive; without it `WasmExecFile` stays empty and the frontend falls back to `/assets/js/wasm_exec.js` which does not exist on the server.

## Fix
Added `pre_command` and `extra_files` to copy and bundle `wasm_exec.js` from the Go toolchain — matching the pattern already used in `flappy-bird.yml`.