### PR TITLE
feat(game-template): align with match-3 and flappy-bird patterns

### DIFF
--- a/game-template/archetype/archetype.go
+++ b/game-template/archetype/archetype.go
@@ -2,17 +2,9 @@ package archetype
 
 import (
 	"github.com/hajimehoshi/ebiten/v2/audio"
-	"github.com/solarlune/resolv"
 	"github.com/soockee/terminal-games/game-template/component"
 	"github.com/yohamta/donburi"
 )
-
-// NewSpace creates a singleton entity holding the resolv.Space.
-func NewSpace(w donburi.World, width, height, cellW, cellH int) {
-	e := w.Entry(w.Create(component.Space))
-	space := resolv.NewSpace(width, height, cellW, cellH)
-	component.Space.Set(e, space)
-}
 
 // NewDebug creates the singleton debug toggle entity.
 func NewDebug(w donburi.World) {
@@ -32,10 +24,10 @@ func NewScore(w donburi.World, target int) {
 	component.Score.Set(e, &component.ScoreData{Target: target})
 }
 
-// NewGameOver creates the singleton game-over state entity.
-func NewGameOver(w donburi.World) {
-	e := w.Entry(w.Create(component.GameOver))
-	component.GameOver.Set(e, &component.GameOverData{})
+// NewGameState creates the singleton game state entity.
+func NewGameState(w donburi.World) {
+	e := w.Entry(w.Create(component.GameState))
+	component.GameState.Set(e, &component.GameStateData{})
 }
 
 // NewAudio creates the singleton audio entity with pre-decoded players.

--- a/game-template/archetype/config.go
+++ b/game-template/archetype/config.go
@@ -1,9 +1,1 @@
 package archetype
-
-// SpawnConfig holds game-design tuning knobs for entity creation.
-// Add your game-specific fields here (e.g. velocities, gaps, counts).
-type SpawnConfig struct {
-	// Example fields — replace with your game's tuning knobs:
-	// PlayerSpeed float64
-	// EnemyCount  int
-}

--- a/game-template/assets/assets.go
+++ b/game-template/assets/assets.go
@@ -2,5 +2,5 @@ package assets
 
 import "embed"
 
-//go:embed ldtk/*
+//go:embed all:ldtk/*
 var FS embed.FS

--- a/game-template/component/component.go
+++ b/game-template/component/component.go
@@ -5,17 +5,8 @@ import (
 
 	"github.com/hajimehoshi/ebiten/v2"
 	"github.com/hajimehoshi/ebiten/v2/audio"
-	"github.com/solarlune/resolv"
 	"github.com/yohamta/donburi"
 )
-
-// ---- Shape (resolv collision shape, owned per-entity) ----
-
-type ShapeData struct {
-	Shape resolv.IShape
-}
-
-var Shape = donburi.NewComponentType[ShapeData]()
 
 // ---- Sprite rendering ----
 
@@ -41,10 +32,6 @@ type ColorData struct {
 
 var Color = donburi.NewComponentType[ColorData]()
 
-// ---- Resolv Space (singleton) ----
-
-var Space = donburi.NewComponentType[resolv.Space]()
-
 // ---- Score (singleton) ----
 
 type ScoreData struct {
@@ -54,16 +41,17 @@ type ScoreData struct {
 
 var Score = donburi.NewComponentType[ScoreData]()
 
-// ---- GameOver (singleton) ----
+// ---- GameState (singleton) ----
 
-type GameOverData struct {
+type GameStateData struct {
 	Dead    bool
 	Started bool // false until first input
 	Restart bool // set by input to signal a level reload
 	Won     bool // true when win condition is met
+	Paused  bool // true while the game is paused
 }
 
-var GameOver = donburi.NewComponentType[GameOverData]()
+var GameState = donburi.NewComponentType[GameStateData]()
 
 // ---- Camera (singleton) ----
 

--- a/game-template/game/game.go
+++ b/game-template/game/game.go
@@ -5,10 +5,13 @@ import (
 	"io"
 	"io/fs"
 	"log"
+	"path/filepath"
+	"strings"
 
 	"github.com/hajimehoshi/ebiten/v2"
 	"github.com/hajimehoshi/ebiten/v2/audio"
 	"github.com/hajimehoshi/ebiten/v2/audio/mp3"
+	"github.com/hajimehoshi/ebiten/v2/audio/vorbis"
 	"github.com/hajimehoshi/ebiten/v2/audio/wav"
 	ldtkgo "github.com/soockee/ldtk-super-simple-loader"
 	"github.com/soockee/terminal-games/game-template/archetype"
@@ -34,15 +37,14 @@ type GameConfig struct {
 // LevelConfig holds per-level overrides. Systems and Renderers here are
 // appended after the game-wide ones.
 type LevelConfig struct {
-	archetype.SpawnConfig
 	Systems   []SystemFunc
 	Renderers []RendererFunc
 }
 
 // AudioConfig defines the asset paths for background music and SFX.
 type AudioConfig struct {
-	BGMusicPath string            // path inside embed FS (mp3)
-	SFX         map[string]string // name → path inside embed FS (wav)
+	BGMusicPath string            // path inside embed FS (mp3/ogg)
+	SFX         map[string]string // name → path inside embed FS (wav/mp3/ogg)
 }
 
 // AudioState holds the decoded audio context and players.
@@ -62,18 +64,36 @@ func InitAudio(fsys fs.FS, cfg AudioConfig) *AudioState {
 	ctx := audio.NewContext(sampleRate)
 	state := &AudioState{Ctx: ctx, SFXData: make(map[string][]byte)}
 
-	// Background music (mp3, infinite loop).
+	// Background music (ogg/mp3, infinite loop).
 	if cfg.BGMusicPath != "" {
 		f, err := fsys.Open(cfg.BGMusicPath)
 		if err != nil {
 			log.Printf("audio: open bgm: %v", err)
 		} else {
 			defer f.Close()
-			decoded, err := mp3.DecodeWithSampleRate(sampleRate, f)
-			if err != nil {
-				log.Printf("audio: decode bgm: %v", err)
-			} else {
-				loop := audio.NewInfiniteLoop(decoded, decoded.Length())
+			var decoded io.ReadSeeker
+			var length int64
+			ext := strings.ToLower(filepath.Ext(cfg.BGMusicPath))
+			switch ext {
+			case ".ogg":
+				d, err2 := vorbis.DecodeWithSampleRate(sampleRate, f)
+				if err2 != nil {
+					log.Printf("audio: decode bgm ogg: %v", err2)
+				} else {
+					decoded, length = d, d.Length()
+				}
+			case ".mp3":
+				d, err2 := mp3.DecodeWithSampleRate(sampleRate, f)
+				if err2 != nil {
+					log.Printf("audio: decode bgm mp3: %v", err2)
+				} else {
+					decoded, length = d, d.Length()
+				}
+			default:
+				log.Printf("audio: unsupported bgm format: %s", ext)
+			}
+			if decoded != nil {
+				loop := audio.NewInfiniteLoop(decoded, length)
 				p, err := ctx.NewPlayer(loop)
 				if err == nil {
 					state.BGMusic = p
@@ -82,20 +102,46 @@ func InitAudio(fsys fs.FS, cfg AudioConfig) *AudioState {
 		}
 	}
 
-	// SFX (wav).
+	// SFX (wav/mp3/ogg).
 	for name, path := range cfg.SFX {
 		f, err := fsys.Open(path)
 		if err != nil {
 			log.Printf("audio: open sfx %s: %v", name, err)
 			continue
 		}
-		decoded, err := wav.DecodeWithSampleRate(sampleRate, f)
-		f.Close()
-		if err != nil {
-			log.Printf("audio: decode sfx %s: %v", name, err)
+		var raw []byte
+		ext := strings.ToLower(filepath.Ext(path))
+		switch ext {
+		case ".wav":
+			decoded, err2 := wav.DecodeWithSampleRate(sampleRate, f)
+			if err2 != nil {
+				log.Printf("audio: decode sfx %s (wav): %v", name, err2)
+				f.Close()
+				continue
+			}
+			raw, _ = io.ReadAll(decoded)
+		case ".mp3":
+			decoded, err2 := mp3.DecodeWithSampleRate(sampleRate, f)
+			if err2 != nil {
+				log.Printf("audio: decode sfx %s (mp3): %v", name, err2)
+				f.Close()
+				continue
+			}
+			raw, _ = io.ReadAll(decoded)
+		case ".ogg":
+			decoded, err2 := vorbis.DecodeWithSampleRate(sampleRate, f)
+			if err2 != nil {
+				log.Printf("audio: decode sfx %s (ogg): %v", name, err2)
+				f.Close()
+				continue
+			}
+			raw, _ = io.ReadAll(decoded)
+		default:
+			log.Printf("audio: unsupported sfx format for %s: %s", name, ext)
+			f.Close()
 			continue
 		}
-		raw, _ := io.ReadAll(decoded)
+		f.Close()
 		state.SFXData[name] = raw
 	}
 
@@ -149,11 +195,10 @@ func Build(level *ldtkgo.Level, w donburi.World, gc GameConfig, lc LevelConfig, 
 	scaleY := float64(vh) / float64(level.Height)
 
 	// Singletons.
-	archetype.NewSpace(e.World, level.Width, level.Height, 8, 8)
 	archetype.NewDebug(e.World)
 	archetype.NewCamera(e.World, scaleX, scaleY)
 	archetype.NewScore(e.World, 0)
-	archetype.NewGameOver(e.World)
+	archetype.NewGameState(e.World)
 
 	// Audio.
 	if audioState != nil {

--- a/game-template/go.mod
+++ b/game-template/go.mod
@@ -4,7 +4,6 @@ go 1.24.0
 
 require (
 	github.com/hajimehoshi/ebiten/v2 v2.9.9
-	github.com/solarlune/resolv v0.8.1
 	github.com/soockee/ldtk-super-simple-loader v0.1.0
 	github.com/yohamta/donburi v1.15.7
 )
@@ -16,6 +15,8 @@ require (
 	github.com/ebitengine/purego v0.9.0 // indirect
 	github.com/hajimehoshi/go-mp3 v0.3.4 // indirect
 	github.com/jezek/xgb v1.1.1 // indirect
+	github.com/jfreymuth/oggvorbis v1.0.5 // indirect
+	github.com/jfreymuth/vorbis v1.0.2 // indirect
 	golang.org/x/sync v0.17.0 // indirect
 	golang.org/x/sys v0.36.0 // indirect
 )

--- a/game-template/go.sum
+++ b/game-template/go.sum
@@ -13,8 +13,10 @@ github.com/hajimehoshi/go-mp3 v0.3.4/go.mod h1:fRtZraRFcWb0pu7ok0LqyFhCUrPeMsGRS
 github.com/hajimehoshi/oto/v2 v2.3.1/go.mod h1:seWLbgHH7AyUMYKfKYT9pg7PhUu9/SisyJvNTT+ASQo=
 github.com/jezek/xgb v1.1.1 h1:bE/r8ZZtSv7l9gk6nU0mYx51aXrvnyb44892TwSaqS4=
 github.com/jezek/xgb v1.1.1/go.mod h1:nrhwO0FX/enq75I7Y7G8iN1ubpSGZEiA3v9e9GyRFlk=
-github.com/solarlune/resolv v0.8.1 h1:QkjnTJYB59EJmw+0+f52UbfE149ERU4FTCRICJTYz9k=
-github.com/solarlune/resolv v0.8.1/go.mod h1:iqRbXy78XQ7aDXGZY3abI41Wr80Yv1DqnxzzPvGG6yE=
+github.com/jfreymuth/oggvorbis v1.0.5 h1:u+Ck+R0eLSRhgq8WTmffYnrVtSztJcYrl588DM4e3kQ=
+github.com/jfreymuth/oggvorbis v1.0.5/go.mod h1:1U4pqWmghcoVsCJJ4fRBKv9peUJMBHixthRlBeD6uII=
+github.com/jfreymuth/vorbis v1.0.2 h1:m1xH6+ZI4thH927pgKD8JOH4eaGRm18rEE9/0WKjvNE=
+github.com/jfreymuth/vorbis v1.0.2/go.mod h1:DoftRo4AznKnShRl1GxiTFCseHr4zR9BN3TWXyuzrqQ=
 github.com/soockee/ldtk-super-simple-loader v0.1.0 h1:UrNVrIcVfEkgau9Eh1/P58RRZ1Bpg6RpLd3Xm83ec74=
 github.com/soockee/ldtk-super-simple-loader v0.1.0/go.mod h1:hr+zKA0+YZZjKNSDKUWzRd/Ht5zMBL/Fb/MwwQXeG5A=
 github.com/yohamta/donburi v1.15.7 h1:so/vHf1L133d0SFVrCUzMMueh2ko39wRkrcpNLdzvz8=

--- a/game-template/main.go
+++ b/game-template/main.go
@@ -5,9 +5,11 @@ import (
 	"log"
 
 	"github.com/hajimehoshi/ebiten/v2"
+	"github.com/hajimehoshi/ebiten/v2/inpututil"
 	ldtkgo "github.com/soockee/ldtk-super-simple-loader"
 	"github.com/soockee/terminal-games/game-template/assets"
 	"github.com/soockee/terminal-games/game-template/component"
+	"github.com/soockee/terminal-games/game-template/event"
 	"github.com/soockee/terminal-games/game-template/game"
 	"github.com/soockee/terminal-games/game-template/system"
 	"github.com/yohamta/donburi"
@@ -136,12 +138,32 @@ func (g *Game) Update() error {
 		}
 	}
 
+	// Pause toggle (P key).
+	if inpututil.IsKeyJustPressed(ebiten.KeyP) {
+		if entry, ok := component.GameState.First(g.loaded.ECS.World); ok {
+			gs := component.GameState.Get(entry)
+			if gs.Started && !gs.Won && !gs.Dead {
+				gs.Paused = !gs.Paused
+				event.AudioEvent.Publish(g.loaded.ECS.World, event.AudioEventData{Name: "pause"})
+			}
+		}
+	}
+
+	// Skip ECS update while paused.
+	if entry, ok := component.GameState.First(g.loaded.ECS.World); ok {
+		gs := component.GameState.Get(entry)
+		if gs.Paused {
+			system.ProcessEvents(g.loaded.ECS)
+			return nil
+		}
+	}
+
 	g.loaded.ECS.Update()
 
 	// Check restart.
-	if entry, ok := component.GameOver.First(g.loaded.ECS.World); ok {
-		go_ := component.GameOver.Get(entry)
-		if go_.Restart {
+	if entry, ok := component.GameState.First(g.loaded.ECS.World); ok {
+		gs := component.GameState.Get(entry)
+		if gs.Restart {
 			g.loadLevel(0)
 			return nil
 		}

--- a/game-template/system/debug.go
+++ b/game-template/system/debug.go
@@ -2,21 +2,15 @@ package system
 
 import (
 	"fmt"
-	"image/color"
 
 	"github.com/hajimehoshi/ebiten/v2"
 	"github.com/hajimehoshi/ebiten/v2/ebitenutil"
-	"github.com/hajimehoshi/ebiten/v2/vector"
-	"github.com/solarlune/resolv"
-	"github.com/soockee/terminal-games/game-template/component"
-	"github.com/yohamta/donburi"
 	"github.com/yohamta/donburi/ecs"
+
+	"github.com/soockee/terminal-games/game-template/component"
 )
 
-var debugColor = color.RGBA{0, 255, 0, 180}
-
-// DrawDebug renders collision boxes and FPS when debug mode is enabled (F3).
-// Uses the camera projection so overlays match the rendered positions.
+// DrawDebug renders debug info and FPS when debug mode is enabled (F3).
 func DrawDebug(e *ecs.ECS, screen *ebiten.Image) {
 	entry, ok := component.Debug.First(e.World)
 	if !ok {
@@ -27,41 +21,9 @@ func DrawDebug(e *ecs.ECS, screen *ebiten.Image) {
 		return
 	}
 
-	proj := NewProjection(e.World)
-
-	// Draw collision shape for every entity that has a Shape component.
-	component.Shape.Each(e.World, func(entry *donburi.Entry) {
-		s := component.Shape.Get(entry)
-		bounds := s.Shape.Bounds()
-
-		sx := float32(proj.WorldToScreenX(bounds.Min.X))
-		sy := float32(proj.WorldToScreenY(bounds.Min.Y))
-		sw := float32(proj.WorldToScreenW(bounds.Width()))
-		sh := float32(proj.WorldToScreenH(bounds.Height()))
-
-		// Circle shapes get a circle outline; everything else gets a rect.
-		if circle, ok := s.Shape.(*resolv.Circle); ok {
-			cr := float32(proj.WorldToScreenW(circle.Radius()))
-			vector.StrokeCircle(screen, sx+sw/2, sy+sh/2, cr, 1, debugColor, false)
-		} else {
-			vector.StrokeRect(screen, sx, sy, sw, sh, 1, debugColor, false)
-		}
-
-		// Label with tag name
-		label := entityLabel(entry)
-		if label != "" {
-			ebitenutil.DebugPrintAt(screen, label, int(sx), int(sy)-12)
-		}
-	})
-
 	// FPS / TPS counter in top-left
 	fps := fmt.Sprintf("FPS: %.0f  TPS: %.0f", ebiten.ActualFPS(), ebiten.ActualTPS())
 	ebitenutil.DebugPrintAt(screen, fps, 4, 4)
-}
 
-func entityLabel(entry *donburi.Entry) string {
-	switch {
-	default:
-		return ""
-	}
+	// TODO: add game-specific debug overlays here (e.g. collision boxes, grid).
 }

--- a/game-template/system/input.go
+++ b/game-template/system/input.go
@@ -20,19 +20,23 @@ func UpdateInput(e *ecs.ECS) {
 	}
 
 	// Action input: Space, mouse click, or touch.
-	goEntry, goOK := component.GameOver.First(e.World)
+	goEntry, goOK := component.GameState.First(e.World)
 	actionPressed := inpututil.IsKeyJustPressed(ebiten.KeySpace) ||
 		inpututil.IsMouseButtonJustPressed(ebiten.MouseButtonLeft) ||
 		len(inpututil.AppendJustPressedTouchIDs(nil)) > 0
 
 	if goOK && actionPressed {
-		go_ := component.GameOver.Get(goEntry)
-		if go_.Dead || go_.Won {
-			go_.Restart = true
+		gs := component.GameState.Get(goEntry)
+		if gs.Paused {
+			gs.Paused = false
 			return
 		}
-		if !go_.Started {
-			go_.Started = true
+		if gs.Dead || gs.Won {
+			gs.Restart = true
+			return
+		}
+		if !gs.Started {
+			gs.Started = true
 		}
 	}
 

--- a/game-template/system/movement.go
+++ b/game-template/system/movement.go
@@ -6,15 +6,15 @@ import (
 )
 
 // UpdateMovement applies velocity and physics to game entities.
-// Gates on Started && !Dead && !Won so nothing moves before the game begins
-// or after it ends.
+// Gates on Started && !Dead && !Won && !Paused so nothing moves before
+// the game begins, after it ends, or while paused.
 func UpdateMovement(e *ecs.ECS) {
-	entry, ok := component.GameOver.First(e.World)
+	entry, ok := component.GameState.First(e.World)
 	if !ok {
 		return
 	}
-	go_ := component.GameOver.Get(entry)
-	if !go_.Started || go_.Dead || go_.Won {
+	gs := component.GameState.Get(entry)
+	if !gs.Started || gs.Dead || gs.Won || gs.Paused {
 		return
 	}
 

--- a/game-template/system/render.go
+++ b/game-template/system/render.go
@@ -29,28 +29,34 @@ func DrawScore(e *ecs.ECS, screen *ebiten.Image) {
 	ebitenutil.DebugPrintAt(screen, text, bounds.Dx()/2-10, 10)
 }
 
-// DrawHUD renders overlays for game state: start prompt, game over, or win.
+// DrawHUD renders overlays for game state: start prompt, pause, game over, or win.
 func DrawHUD(e *ecs.ECS, screen *ebiten.Image) {
-	entry, ok := component.GameOver.First(e.World)
+	entry, ok := component.GameState.First(e.World)
 	if !ok {
 		return
 	}
-	go_ := component.GameOver.Get(entry)
+	gs := component.GameState.Get(entry)
 	bounds := screen.Bounds()
 	cx := bounds.Dx() / 2
+	cy := bounds.Dy() / 2
 
-	if !go_.Started {
-		ebitenutil.DebugPrintAt(screen, "Tap or press Space to start", cx-80, bounds.Dy()/2)
+	if gs.Paused {
+		ebitenutil.DebugPrintAt(screen, "PAUSED", cx-20, cy-10)
+		ebitenutil.DebugPrintAt(screen, "Press P or tap to resume", cx-75, cy+10)
 		return
 	}
-	if go_.Won {
-		ebitenutil.DebugPrintAt(screen, "YOU WIN!", cx-30, bounds.Dy()/2-20)
-		ebitenutil.DebugPrintAt(screen, "Tap or press Space to restart", cx-90, bounds.Dy()/2+10)
+	if !gs.Started {
+		ebitenutil.DebugPrintAt(screen, "Tap or press Space to start", cx-80, cy)
 		return
 	}
-	if go_.Dead {
-		ebitenutil.DebugPrintAt(screen, "GAME OVER", cx-35, bounds.Dy()/2-20)
-		ebitenutil.DebugPrintAt(screen, "Tap or press Space to restart", cx-90, bounds.Dy()/2+10)
+	if gs.Won {
+		ebitenutil.DebugPrintAt(screen, "YOU WIN!", cx-30, cy-20)
+		ebitenutil.DebugPrintAt(screen, "Tap or press Space to restart", cx-90, cy+10)
+		return
+	}
+	if gs.Dead {
+		ebitenutil.DebugPrintAt(screen, "GAME OVER", cx-35, cy-20)
+		ebitenutil.DebugPrintAt(screen, "Tap or press Space to restart", cx-90, cy+10)
 		return
 	}
 }


### PR DESCRIPTION
## Summary

Brings the game-template up to date with patterns established in match-3 (primarily) and flappy-bird.

### Changes
- **Rename** `GameOver` → `GameState` with added `Paused` field
- **Add** pause toggle (P key) and pause HUD overlay
- **Support** multi-format audio (ogg/mp3/wav) in `InitAudio`
- **Remove** `resolv` dependency (optional — add when your game needs physics)
- **Remove** empty `physics/` folder and `SpawnConfig` boilerplate
- **Simplify** `LevelConfig` to only `Systems` + `Renderers` overrides
- **Update** embed directive to `all:ldtk/*`

### Migration
Games forked from the old template need to:
1. Rename `component.GameOver` → `component.GameState` (and `GameOverData` → `GameStateData`)
2. If using resolv, re-add it as a direct dependency and restore `component.Space`/`Shape`
